### PR TITLE
Share libs between node and deltachat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# Flatpak packaging for Delta Chat Desktop
+
+## Building
+
+If you'd like to locally build this flapak, you'll need both `flatpak`
+and `flatpak-builder` installed.  E.g. on Debian you can run `apt
+install flatpak flatpak-builder` to install these tools.  See
+https://flatpak.org/setup/ for more information on this for your
+platform.
+
+### flatpak dependencies
+
+If you haven't done so yet, you need to have
+[flathub](https://flathub.org) set up as a remote repository:
+
+```
+flatpak remote-add --if-not-exists \
+    flathub https://flathub.org/repo/flathub.flatpakrepo
+```
+
+You also need to install the required flatpak runtime, SDK and
+electron BaseApp.  At the time of this writing they are the 18.08
+versions, but check the `chat.delta.desktop.yml`'s `runtime-version`
+and `base-version` properties for the current version numbers.
+
+```
+flatpak install flathub \
+    org.freedesktop.Platform//18.08 \
+    org.freedesktop.Sdk//18.08 \
+    io.atom.electron.BaseApp//18.08
+```
+
+
+### Building the application
+
+To simply build the application in a build-directory invoke
+`flatpak-builder` pointing to the manifest:
+```
+flatpak-builder build-dir chat.delta.desktop.yml
+```
+
+To install the local build you can add the `--install` flag.  To
+upload the built application to a repository, which can just be a
+local directory, add the `--repo=repo` flag.
+
+
+### Uploading to flathub
+
+Each commit to the https://github.com/flathub/chat.delta.desktop
+master branch will result in a new release being published to
+flathub.  So once a pull request is merged no more work needs to be
+done to publish the release.
+
+
+## Upgrading to a new release
+
+
+### Re-generating npm sources
+
+Since flatpak does not allow the build to download things while
+building we have to resolve all the npm dependencies statically
+beforehand.  This is done by letting npm put the dependencies into a
+`package-lock.json` file without actually downloading them and than
+converting that into a manifest snipped called
+`generated-sources.json`.
+
+You need to generate the `package-lock.json` file from the
+deltachat-desktop release you need.  Go to the git repository,
+chechout the correct tag and run (e.g. using docker):
+
+```
+docker run --rm -it -u 1000:1000 -v (pwd):/bindings -w /bindings node:11-stretch npm install --package-lock-only
+```
+
+After this move the file to this repository here.
+
+Now to create the `generated-sources.json` file you need a copy of the
+https://github.com/flatpak/flatpak-builder-tools.git repository and
+invoke the `npm/flatpak-npm-generator.py` script, e.g.:
+
+```
+python3 ../flatpak-builder-tools/npm/flatpak-npm-generator.py package-lock.json
+```
+
+This will produce the `generated-sources.json` file which is referenced
+in the `chat.delta.desktop.yml` manifest.

--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -25,6 +25,7 @@ build-options:
 
 
 modules:
+
   # Build node.js.  We need to dynamically link to OpenSSL and libz
   # because our deltachat-node extension module also uses these
   # libraries and we need to use the same objects for each symbol.
@@ -55,7 +56,6 @@ modules:
       # we get build-failures if they are not present.
       - --enable-shared
       - --disable-cmulocal
-      - --disable-cmulocal
       - --disable-sample
       - --disable-obsolete_cram_attr
       - --disable-obsolete_digest_attr
@@ -75,7 +75,6 @@ modules:
         url: https://ftp.osuosl.org/pub/blfs/conglomeration/cyrus-sasl/cyrus-sasl-2.1.27.tar.gz
         sha256: 26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5
 
-
   - name: delta
     buildsystem: simple
     build-options:
@@ -91,82 +90,60 @@ modules:
         # Tell the chromedriver npm package where we pre-downloaded things.
         ELECTRON_CACHE: /run/build/delta/npm-cache
     build-commands:
-        - npm install  --offline --cache=/run/build/delta/npm-cache/  --verbose
-        - npm run build  --offline --cache=/run/build/delta/npm-cache/  --verbose
-        # This seems to be the appropriate command equivalent to a "make install".
-        # - ./node_modules/.bin/electron-builder build --linux dir
-        # It seems to be provided by the "pack" shortcut.
-        - npm run pack  --offline --cache=/run/build/delta/npm-cache/  --verbose
-        - mkdir -p /app/delta /app/bin
-        - cp -ar dist/linux-unpacked/* /app/delta/
-        # Not knowing how else to install the app into a certain prefix, we copy everything :(
-        # - cp -ra * /app/
-        - install run.sh /app/bin/
-        # FIXME: These may fall out of "pack", although I can't find them in "dist" :-/
-        - install -Dm 0644 chat.delta.desktop.desktop  /app/share/applications/chat.delta.desktop.desktop
-        - install -Dm 0644 static/chat.delta.desktop.appdata.xml  /app/share/metainfo/chat.delta.desktop.appdata.xml
-        - install -Dm 0644 delta-v7-pathed.svg /app/share/icons/hicolor/scalable/apps/chat.delta.desktop.svg
-        
+      # Install the deltachat-desktop npm package
+      - npm install --offline --cache=/run/build/delta/npm-cache/ --verbose
+      - npm run pack --offline --cache=/run/build/delta/npm-cache/ --verbose
+      - mkdir -p /app/delta
+      - cp -ar dist/linux-unpacked/* /app/delta/
 
+      # Install the required static files
+      - install run.sh /app/bin/run.sh
+      - install -Dm 0644 chat.delta.desktop.desktop  /app/share/applications/chat.delta.desktop.desktop
+      - install -Dm 0644 chat.delta.desktop.appdata.xml  /app/share/metainfo/chat.delta.desktop.appdata.xml
+      - install -Dm 0644 delta-v7-pathed.svg /app/share/icons/hicolor/scalable/apps/chat.delta.desktop.svg
     sources:
-        # Of course, not all electron packages are equal *sigh*
-        # This one downloads files at installation time.
-        # Taken from https://github.com/electron/chromedriver/issues/28#issuecomment-427839364
-        - type: file
-          url: https://github.com/electron/electron/releases/download/v3.0.0/chromedriver-v3.0.0-linux-x64.zip
-          sha256: 31c59d42d80001721dbdbf2f2c8b3b527bdb8df38c766b020329cb46cf1d3bb4
-          dest: npm-cache
+      # The chromedriver package tries to download a bunch of files
+      # outside of the normal npm dependencies.  Pre-download them and
+      # use ELECTRON_CACHE to point to them.
+      # Taken from https://github.com/electron/chromedriver/issues/28#issuecomment-42783936
+      - type: file
+        url: https://github.com/electron/electron/releases/download/v3.0.0/chromedriver-v3.0.0-linux-x64.zip
+        sha256: 31c59d42d80001721dbdbf2f2c8b3b527bdb8df38c766b020329cb46cf1d3bb4
+        dest: npm-cache
+      - type: file
+        url: https://github.com/electron/electron/releases/download/v3.0.0/SHASUMS256.txt
+        sha256: 6560dd88350be568ff29cdb1cdb05e68304268b821b1d5040f9a5fde901ef670
+        dest-filename: SHASUMS256.txt-3.0.0
+        dest: npm-cache
 
-        - type: file
-          url: https://github.com/electron/electron/releases/download/v3.0.0/chromedriver-v3.0.0-linux-arm64.zip
-          sha256: 6eefd2dcc78f830ab8ba12836a5c36a6b286b2eda03a3562cabdaa51c9c8baa1
-          dest: npm-cache
+      - type: archive
+        url: https://github.com/deltachat/deltachat-desktop/archive/v0.101.0.tar.gz
+        sha256: 2731aedc9d494570d01bf0005ac37db55e0e7b44b3276cf1444852621ae02ace
 
-        - type: file
-          url: https://github.com/electron/electron/releases/download/v3.0.0/chromedriver-v3.0.0-linux-armv7l.zip
-          sha256: afa53c2150b2a2e953b803c40e8cec0109392ffbc291fb143304c67777197d87
-          dest: npm-cache
+      - type: file
+        url: https://raw.githubusercontent.com/deltachat/interface/970c5df39866695b5e8ebdd73caa68cbb6de5242/icons/delta-v7-pathed.svg
+        sha256: 1787a9dfdd80301ae5dbe48105bd58215c6552bd8ecfa4efd15fe6d31ba31274
+        dest-filename: delta-v7-pathed.svg
 
-        - type: file
-          url: https://github.com/electron/electron/releases/download/v3.0.0/chromedriver-v3.0.0-linux-ia32.zip
-          sha256: 5d6f62b534b58efc9682e21a41a3991f109b1a78481b067cb1b3be5a0d0f461c
-          dest: npm-cache
+      - type: file
+        path: package-lock.json
+        dest-filename: package-lock.json
 
-        - type: file
-          url: https://github.com/electron/electron/releases/download/v3.0.0/SHASUMS256.txt
-          sha256: 6560dd88350be568ff29cdb1cdb05e68304268b821b1d5040f9a5fde901ef670
-          dest-filename: SHASUMS256.txt-3.0.0
-          dest: npm-cache
+      - type: file
+        path: chat.delta.desktop.desktop
 
-        - type: archive
-          url: https://github.com/deltachat/deltachat-desktop/archive/v0.101.0.tar.gz
-          sha256: 2731aedc9d494570d01bf0005ac37db55e0e7b44b3276cf1444852621ae02ace
+      - type: file
+        path: chat.delta.desktop.256.png
+        dest-filename: chat.delta.desktop.png
 
-        - type: file
-          url: https://raw.githubusercontent.com/deltachat/interface/970c5df39866695b5e8ebdd73caa68cbb6de5242/icons/delta-v7-pathed.svg
-          sha256: 1787a9dfdd80301ae5dbe48105bd58215c6552bd8ecfa4efd15fe6d31ba31274
-          dest-filename: delta-v7-pathed.svg
-          
-        - type: file
-          path: package-lock.json
-          dest-filename: package-lock.json
+      - type: file
+        path: chat.delta.desktop.appdata.xml
 
-        - type: file # This is generated somehow by that electron builder, but I can't find it.
-          path: chat.delta.desktop.desktop
+      - type: script
+        dest-filename: run.sh
+        commands:
+          - /app/delta/deltachat-desktop
 
-        - type: file # This is generated somehow by that electron builder, but I can't find it.
-          path: chat.delta.desktop.256.png
-          dest-filename: chat.delta.desktop.png
-
-        - type: file # This is generated somehow by that electron builder, but I can't make it biuld it.
-          path: chat.delta.desktop.appdata.xml
-          dest-filename: static/chat.delta.desktop.appdata.xml
-
-        - type: script
-          dest-filename: run.sh
-          commands:
-            - /app/delta/deltachat-desktop
-          
-
-        # This needs to go to the bottom so that the commands in that file can see package.json and friends.
-        - generated-sources.json
+      # All the generated npm downloads, see README.md how to create
+      # this file.
+      - generated-sources.json


### PR DESCRIPTION
The most important change is to build node.js with libssl and libz as
shared libraries.  Later on deltachat-core gets build using these same
libraries and all the objects can happily live together in the same
process.  Before we relied a bit on luck that the versions were
compatible.

Secondly this adds a readme, this is a work in progress.

Than the smaller changes:

- Clean up unused files in libsasl to reduce the result a little.

- Be more explicit about the build system used rather than let it
  autodetect.

- Pass options to the libsasl build as well, to customise the build a
  bit better.

- Remove a few unneeded chromedriver sources

- Document the required environment variables a little.

- Remove redundant `npm run build` command as this is covered in the
  `npm run pack` one (in packages.js).