### PR TITLE
Nodejs upgrade

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -44,8 +44,8 @@ modules:
       - /app/lib/node_modules/npm/scripts
     sources:
       - type: archive
-        url: https://nodejs.org/dist/v8.13.0/node-v8.13.0.tar.xz
-        sha256: 2aa99474a336c6339d14f08cc27d387c5168e6fb6cbcaaea1d5ff7aa89642de2
+        url: https://nodejs.org/dist/v10.15.3/node-v10.15.3.tar.gz
+        sha256: db460a63d057ac015b75bb6a879fcbe2fefaaf22afa4b6f6445b9db61ce2270d
 
   # libsasl is not in the org.freedekstop.Platform runtime but needed
   # by deltachat-core.


### PR DESCRIPTION
This PR is based on https://github.com/flathub/chat.delta.desktop/pull/6 so the diff is actually tiny, which will be obvious once the original PR is merged.

@muelli do you know what the reason was to use an older nodejs version before?  I tested it with this and it seems to work fine.