### PR TITLE
Publish new releases 1h after PRs are merged

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
     "only-arches": ["x86_64"]
+    "publish-delay-hours": 1
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
     "publish-delay-hours": 1
 }


### PR DESCRIPTION
The 24h delay is a long delay to get a release out of the door.  It
works for packaging upgrades but not for upstream releases.