### PR TITLE
Use the default publish delay again

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "only-arches": ["x86_64"],
-    "publish-delay-hours": 1
+    "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
We can publish faster from the buildbot page if we need it.