### PR TITLE
Use zypak-wrapper instead of disabling sandbox

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -1,5 +1,4 @@
 app-id: chat.delta.desktop
-# I have no idea, actually, what a base does and whether we need it.
 base: org.electronjs.Electron2.BaseApp
 base-version: '19.08'
 runtime: org.freedesktop.Platform
@@ -91,7 +90,8 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
-          - /app/delta/deltachat-desktop --no-sandbox
+          - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
+          - exec zypak-wrapper /app/delta/deltachat-desktop "$@"
 
       # All the generated npm downloads, see README.md how to create
       # this file.  This needs to go to the bottom so that the


### PR DESCRIPTION
This is better fix for https://github.com/flathub/chat.delta.desktop/issues/29 which keeps security gained from electron internal sandboxing.

Also: remove weird (leftover?) comment. Electron baseapp provides common electron dependencies for desktop integration which you don't have to bundle themselves here. It also ships zypak-wrapper which is useful for above.

Also: export `TMPDIR`  to solve multiple instance issue.

Also: using `exec` will close leftover shell process.

Also: add `$@` at the end of command which allows to pass custom arguments to app.

Fixes https://github.com/flathub/chat.delta.desktop/issues/22
Fixes https://github.com/flathub/chat.delta.desktop/issues/29