### PR TITLE
Allow webcam access for QR code scans

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --device=dri         # Without DRI the app doesn't come up :-/
+  - --device=all         # Webcam access for QR code scans
   - --socket=pulseaudio  # Record and play voice messages
   - --filesystem=home
   - --share=network


### PR DESCRIPTION
Unfortunately, Flatpak doesn't seem to handle webcam access specifically, so broad device access is needed for the QR code scanner. This scanner was [added in 1.3.0](https://github.com/deltachat/deltachat-desktop/releases/tag/v1.3.0).