### PR TITLE
Update to v1.15.0

### DIFF
--- a/chat.delta.desktop.appdata.xml
+++ b/chat.delta.desktop.appdata.xml
@@ -34,6 +34,7 @@
   <url type="donation">https://delta.chat/en/contribute</url>
   <url type="translate">https://www.transifex.com/delta-chat/public/</url>
   <releases>
+    <release version="v1.15.0" date="2021-02-11" />
     <release version="v1.14.1" date="2020-12-25" />
     <release version="v1.13.1" date="2020-10-07" />
     <release version="v1.13.0" date="2020-10-01" />

--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -76,8 +76,8 @@ modules:
 
       - type: git
         url: https://github.com/deltachat/deltachat-desktop.git
-        tag: v1.14.1
-        commit: c6273f7449c46ad938b3cbb3285ca511815ade50
+        tag: v1.15.0
+        commit: ab0587416f8fc4aeeef4589cbade4d23dabef08a
 
       - type: file
         url: https://raw.githubusercontent.com/deltachat/interface/970c5df39866695b5e8ebdd73caa68cbb6de5242/icons/delta-v7-pathed.svg

--- a/deltachat-core-rust.yaml
+++ b/deltachat-core-rust.yaml
@@ -40,6 +40,11 @@ modules:
         url: https://static.rust-lang.org/dist/2020-08-03/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
         sha256: df4cbd0eb18334723aeb0dee9e3800465f3af7eaac4a7a39a7ec1ad3eb0b08e0
 
+      - type: archive
+        only-arches: ["aarch64"]
+        url: https://static.rust-lang.org/dist/2020-08-03/rust-nightly-aarch64-unknown-linux-gnu.tar.gz
+        sha256: aa93f75fcab54287cb0922002b1beb3ab6f43d95b1f944e58659d0307df3c7ee
+
 sources:
   - type: archive
     url: https://github.com/deltachat/deltachat-core-rust/archive/1.50.0.tar.gz


### PR DESCRIPTION
hm. For some reason, the generated-sources don't seem to be sufficient.
I have ran `python3 ~/vcs/flatpak-builder-tools/node/flatpak-node-generator.py npm ~/vcs/deltachat-desktop/package-lock.json --xdg-layout  --electron-node-headers --recursive -s --output generated-sources-npm.json`, but somehow it fails on "electron@11.1.0". Hm.

This also scrolls by:

```
npm info lifecycle electron-chromedriver@10.0.0~install: electron-chromedriver@10.0.0

> electron-chromedriver@10.0.0 install /run/build/delta/node_modules/electron-chromedriver
> node ./download-chromedriver.js

(node:13) UnhandledPromiseRejectionWarning: RequestError: getaddrinfo EAI_AGAIN github.com github.com:443
    at ClientRequest.request.once.error (/run/build/delta/node_modules/got/source/request-as-event-emitter.js:178:14)
    at Object.onceWrapper (events.js:286:20)
    at ClientRequest.emit (events.js:203:15)
    at ClientRequest.origin.emit.args (/run/build/delta/node_modules/@szmarczak/http-timer/source/index.js:37:11)
    at TLSSocket.socketErrorListener (_http_client.js:401:9)
    at TLSSocket.emit (events.js:198:13)
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
(node:13) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:13) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

```

and this:

```
> electron@11.1.0 postinstall /run/build/delta/node_modules/electron
> node install.js

RequestError: getaddrinfo EAI_AGAIN github.com github.com:443
    at ClientRequest.request.once.error (/run/build/delta/node_modules/got/source/request-as-event-emitter.js:178:14)
    at Object.onceWrapper (events.js:286:20)
    at ClientRequest.emit (events.js:203:15)
    at ClientRequest.origin.emit.args (/run/build/delta/node_modules/@szmarczak/http-timer/source/index.js:37:11)
    at TLSSocket.socketErrorListener (_http_client.js:401:9)
    at TLSSocket.emit (events.js:198:13)
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)

```