### PR TITLE
core: Compile Rust with debug symbols to have better stacktraces

### DIFF
--- a/deltachat-core-rust.yaml
+++ b/deltachat-core-rust.yaml
@@ -9,6 +9,11 @@ build-options:
     # deltachat-ffi/build.rs uses this to create deltachat.pc,
     # should locate deltachat.so.
     PREFIX: /app/lib
+
+    # The intention is to have a release build with debugging symbols.
+    # The flatpak build process should separate the debug symbols.
+    RUSTFLAGS: "-g"
+
   append-path: /app/lib/sdk/rust-nightly/bin
 cleanup:
     - /include


### PR DESCRIPTION
Not that it has ever crashed yet, but it seems to be best practice
to have then when we need them.

They should be stripped during the build process so it shouldn't affect the resulting binaries.