### PR TITLE
Issue #48 - Use the rust nightly SDK

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -6,12 +6,12 @@ runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node12
+  - org.freedesktop.Sdk.Extension.rust-nightly
 command: /app/bin/run.sh
 finish-args:
   - --socket=x11
   - --share=ipc
-  - --device=dri         # Without DRI the app doesn't come up :-/
-  - --device=all         # Webcam access for QR code scans
+  - --device=all         # Webcam access for QR code scans, include DRI
   - --socket=pulseaudio  # Record and play voice messages
   - --filesystem=home
   - --share=network

--- a/deltachat-core-rust.yaml
+++ b/deltachat-core-rust.yaml
@@ -14,7 +14,7 @@ build-options:
     # The flatpak build process should separate the debug symbols.
     RUSTFLAGS: "-g"
 
-  append-path: /app/lib/sdk/rust-nightly/bin
+  append-path: /usr/lib/sdk/rust-nightly/bin
 cleanup:
     - /include
     - /lib/libdeltachat.a
@@ -31,24 +31,6 @@ build-commands:
   - install -D -m a+r ./target/release/pkgconfig/deltachat.pc  /app/lib/pkgconfig/deltachat.pc
   - find /app -name '*delta*.so'
   - pkg-config --libs deltachat
-modules:
-  - name: rust-nightly
-    cleanup:
-      # We don't need rust in the final application, only build-time
-      - /lib/sdk/rust-nightly
-    buildsystem: simple
-    build-commands:
-      - ./install.sh --prefix=/app/lib/sdk/rust-nightly --disable-ldconfig --verbose
-    sources:
-      - type: archive
-        only-arches: ["x86_64"]
-        url: https://static.rust-lang.org/dist/2020-08-03/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-        sha256: df4cbd0eb18334723aeb0dee9e3800465f3af7eaac4a7a39a7ec1ad3eb0b08e0
-
-      - type: archive
-        only-arches: ["aarch64"]
-        url: https://static.rust-lang.org/dist/2020-08-03/rust-nightly-aarch64-unknown-linux-gnu.tar.gz
-        sha256: aa93f75fcab54287cb0922002b1beb3ab6f43d95b1f944e58659d0307df3c7ee
 
 sources:
   - type: archive


### PR DESCRIPTION
Use the rust-nightly SDK

Testing the build on x86_64.
(a crate fail build on aarch64)