### PR TITLE
remove unused build dependencies from release

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -27,6 +27,10 @@ modules:
   - deltachat-core-rust.yaml
 
   - name: delta
+    cleanup:
+        # remove stuff that is not required at runtime
+        - /app/bin/sccache
+        - /app/node
     buildsystem: simple
     build-options:
       append-path: /usr/lib/sdk/node12/bin


### PR DESCRIPTION

for #63, but deltachat node prebuilds and core sourcecode are not removed by this pr