### PR TITLE
remove unused build dependencies from release

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -21,6 +21,9 @@ modules:
   - deltachat-core-rust.yaml
 
   - name: delta
+    cleanup:
+        - /delta/resources/app/node_modules/deltachat-node/deltachat-core-rust
+        - /delta/resources/app/node_modules/deltachat-node/prebuilds
     buildsystem: simple
     build-options:
       append-path: /usr/lib/sdk/node14/bin


### PR DESCRIPTION
delta/resources/app/node_modules/deltachat-node/prebuilds
is not needed, because we build it ourselves. It should save 19MB.

delta/resources/app/node_modules/deltachat-node/deltachat-core-rust
is not needed, because we don't need sources in the binary distribution.
It should save 2.7MB.