### PR TITLE
wip: fix startup crash of 1.22.2 release

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -48,6 +48,8 @@ modules:
       - node --version
       - npm --version
       - npm cache verify
+      # patch pkg-config until https://github.com/deltachat/deltachat-core-rust/issues/2755 is fixed
+      - sed -i "s/-L\${libdir} //" /app/lib/pkgconfig/deltachat.pc
       - pkg-config --libs deltachat
       - pkg-config --cflags deltachat
       - mkdir -p $FLATPAK_BUILDER_BUILDDIR/flatpak-node/tmp


### PR DESCRIPTION
patch pkgconfig file for now so that dc-node really links the core
see https://github.com/deltachat/deltachat-desktop/issues/2392#issuecomment-945021167