### PR TITLE
attempt to detect the use of the correct core version

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -69,6 +69,9 @@ modules:
       - install -Dm 0644 ../chat.delta.desktop.desktop  /app/share/applications/chat.delta.desktop.desktop
       - install -Dm 0644 ../chat.delta.desktop.appdata.xml  /app/share/metainfo/chat.delta.desktop.appdata.xml
       - install -Dm 0644 ../delta-v7-pathed.svg /app/share/icons/hicolor/scalable/apps/chat.delta.desktop.svg
+
+      # check that the correct core version is being used. Unfortunately, deltachat builds successfully even when the wrong core version is used.
+      - node -e "try{require(\"./app/files/delta/resources/app/node_modules/deltachat-node/binding.js\")} catch (err) {console.log(err);process.exit(1);}"
     subdir: main
     sources:
       # Electron


### PR DESCRIPTION
Deltachat is happy to build with an outdated core version and only complains
at runtime. This tries to detect this type of failure.