### PR TITLE
next for beta4

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -146,8 +146,8 @@ modules:
       # Delta Chat
       - type: git
         url: https://github.com/deltachat/deltachat-desktop.git
-        tag: v1.27.1
-        commit: d2626ca71c9ebf99226a74e176be2388532096df
+        tag: v1.27.2
+        commit: 40780139fd90d678522dd799676b59c975c42eb2
         dest: main
 
       - type: file


### PR DESCRIPTION
- Use sccache to speed up (subsequent) compilation
- update to desktop v1.27.2
