### PR TITLE
update to 1.36.4

### DIFF
--- a/chat.delta.desktop.appdata.xml
+++ b/chat.delta.desktop.appdata.xml
@@ -34,6 +34,7 @@
   <url type="donation">https://delta.chat/en/contribute#donate-money-or-devices</url>
   <url type="translate">https://www.transifex.com/delta-chat/public/</url>
   <releases>
+    <release version="v1.36.4" date="2023-04-23" />
     <release version="v1.34.4" date="2023-02-14" />
     <release version="v1.34.2" date="2023-01-19" />
     <release version="v1.34.1" date="2022-12-22" />

--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -139,8 +139,8 @@ modules:
       # Delta Chat
       - type: git
         url: https://github.com/deltachat/deltachat-desktop.git
-        tag: v1.36.1
-        commit: c7e9f7bad45369dd147c07bcb079027ec9691699
+        tag: v1.36.4
+        commit: 6d91754e9827351dea7fddfd82848f3759937764
         dest: main
 
       - type: file

--- a/deltachat-core-rust.yaml
+++ b/deltachat-core-rust.yaml
@@ -88,8 +88,8 @@ sources:
   #   sha256: 2909661e9e4bab24b482e9c2b2d983a777fa5e6173484ab99571115d5aaa70aa
   - type: git
     url: https://github.com/deltachat/deltachat-core-rust.git
-    tag: v1.112.6
-    commit: 185a0193cce60fd472a41e20205652176f7e552c
+    tag: v1.112.8
+    commit: 2701c135db732f7c9f7f6770d8aa0def1d7cf121
   - generated-sources-rust.json
 
   

--- a/deltachat-core-rust.yaml
+++ b/deltachat-core-rust.yaml
@@ -88,8 +88,8 @@ sources:
   #   sha256: 2909661e9e4bab24b482e9c2b2d983a777fa5e6173484ab99571115d5aaa70aa
   - type: git
     url: https://github.com/deltachat/deltachat-core-rust.git
-    tag: v1.112.8
-    commit: 2701c135db732f7c9f7f6770d8aa0def1d7cf121
+    tag: v1.114.0
+    commit: edfdbbdc90e97de92b5f86a74ecddb3be6a8aa9a
   - generated-sources-rust.json
 
   

--- a/generated-sources-rust.json
+++ b/generated-sources-rust.json
@@ -1,12 +1,6 @@
 [
     {
         "type": "git",
-        "url": "https://github.com/async-email/async-imap",
-        "commit": "90270474a5a494669e7c63c13471d189afdc98ae",
-        "dest": "flatpak-cargo/git/async-imap-9027047"
-    },
-    {
-        "type": "git",
         "url": "https://github.com/deltachat/rust-email",
         "commit": "25702df99254d059483b41417cd80696a258df8e",
         "dest": "flatpak-cargo/git/rust-email-25702df"
@@ -290,15 +284,16 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "shell",
-        "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/async-imap-9027047/.\" \"cargo/vendor/async-imap\""
-        ]
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-imap/async-imap-0.8.0.crate",
+        "sha256": "d11e163a705d0c809dfc886eee95df5117c758539c940c0fe9aa3aa4da5388ce",
+        "dest": "cargo/vendor/async-imap-0.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": null, \"files\": {}}",
-        "dest": "cargo/vendor/async-imap",
+        "contents": "{\"package\": \"d11e163a705d0c809dfc886eee95df5117c758539c940c0fe9aa3aa4da5388ce\", \"files\": {}}",
+        "dest": "cargo/vendor/async-imap-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -312,19 +307,6 @@
         "type": "inline",
         "contents": "{\"package\": \"479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e\", \"files\": {}}",
         "dest": "cargo/vendor/async-mutex-1.4.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-native-tls/async-native-tls-0.4.0.crate",
-        "sha256": "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe",
-        "dest": "cargo/vendor/async-native-tls-0.4.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe\", \"files\": {}}",
-        "dest": "cargo/vendor/async-native-tls-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -655,14 +637,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/byte-pool/byte-pool-0.2.3.crate",
-        "sha256": "f8c7230ddbb427b1094d477d821a99f3f54d36333178eeb806e279bcdcecf0ca",
-        "dest": "cargo/vendor/byte-pool-0.2.3"
+        "url": "https://static.crates.io/crates/byte-pool/byte-pool-0.2.4.crate",
+        "sha256": "c2f1b21189f50b5625efa6227cf45e9d4cfdc2e73582df2b879e9689e78a7158",
+        "dest": "cargo/vendor/byte-pool-0.2.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f8c7230ddbb427b1094d477d821a99f3f54d36333178eeb806e279bcdcecf0ca\", \"files\": {}}",
-        "dest": "cargo/vendor/byte-pool-0.2.3",
+        "contents": "{\"package\": \"c2f1b21189f50b5625efa6227cf45e9d4cfdc2e73582df2b879e9689e78a7158\", \"files\": {}}",
+        "dest": "cargo/vendor/byte-pool-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1149,14 +1131,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.7.crate",
-        "sha256": "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c",
-        "dest": "cargo/vendor/crossbeam-channel-0.5.7"
+        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.8.crate",
+        "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-channel-0.5.7",
+        "contents": "{\"package\": \"a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1713,6 +1695,12 @@
     },
     {
         "type": "inline",
+        "contents": "[package]\nname = \"email\"\nversion = \"0.0.21\"\nauthors = [ \"Nicholas Hollett <niax@niax.co.uk>\",]\ndescription = \"Implementation of RFC 5322 email messages\"\nrepository = \"https://github.com/niax/rust-email\"\ndocumentation = \"https://niax.github.io/rust-email/email/\"\nlicense = \"MIT\"\nbuild = \"build.rs\"\n\n[dependencies]\nencoding = \"0.2.33\"\nchrono = \"0.4.9\"\nlazy_static = \"1.4.0\"\nbase64 = \"0.11.0\"\nrand = \"0.7.2\"\ntime = \"0.1.42\"\n\n[features]\nnightly = []\n\n[build-dependencies]\nversion_check = \"0.9.1\"\n\n[dependencies.encoded-words]\ngit = \"https://github.com/async-email/encoded-words\"\nbranch = \"master\"\n",
+        "dest": "cargo/vendor/email",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
         "contents": "{\"package\": null, \"files\": {}}",
         "dest": "cargo/vendor/email",
         "dest-filename": ".cargo-checksum.json"
@@ -1722,6 +1710,12 @@
         "commands": [
             "cp -r --reflink=auto \"flatpak-cargo/git/encoded-words-d55366b/.\" \"cargo/vendor/encoded-words\""
         ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"encoded-words\"\nversion = \"0.2.0\"\nauthors = [ \"dignifiedquire <me@dignifiedquire.com>\",]\ndocumentation = \"https://docs.rs/encoded-words/\"\nrepository = \"https://github.com/async-email/encoded-words\"\nhomepage = \"https://github.com/async-email/encoded-words\"\ndescription = \"Encoded Words for usage in MIME headers\"\nreadme = \"README.md\"\nlicense = \"Apache-2.0/MIT\"\nedition = \"2018\"\n\n[dependencies]\nthiserror = \"1.0.9\"\nlazy_static = \"1.4.0\"\nhex = \"0.4.0\"\nbase64 = \"0.12.0\"\ncharset = \"0.1.2\"\nencoding_rs = \"0.8.20\"\n\n[dependencies.regex]\nversion = \"1.3.1\"\ndefault-features = false\nfeatures = [ \"std\",]\n",
+        "dest": "cargo/vendor/encoded-words",
+        "dest-filename": "Cargo.toml"
     },
     {
         "type": "inline",
@@ -2933,6 +2927,12 @@
     },
     {
         "type": "inline",
+        "contents": "[[bench]]\nname = \"transport_smtp\"\nharness = false\n\n[[example]]\nname = \"smtp\"\nrequired-features = [ \"smtp-transport\",]\n\n[[example]]\nname = \"smtp_gmail\"\nrequired-features = [ \"smtp-transport\",]\n\n[package]\nname = \"lettre\"\nversion = \"0.9.2\"\ndescription = \"Email client\"\nreadme = \"README.md\"\nhomepage = \"http://lettre.at\"\nrepository = \"https://github.com/lettre/lettre\"\nlicense = \"MIT\"\nauthors = [ \"Alexis Mousset <contact@amousset.me>\",]\ncategories = [ \"email\",]\nkeywords = [ \"email\", \"smtp\", \"mailer\",]\nedition = \"2018\"\n\n[dependencies]\nlog = \"^0.4\"\nfast_chemail = \"^0.9\"\n\n[dev-dependencies]\nenv_logger = \"^0.7\"\nglob = \"^0.3\"\ncriterion = \"^0.3\"\n\n[features]\ndefault = [ \"file-transport\", \"smtp-transport\", \"sendmail-transport\",]\nunstable = []\nserde-impls = [ \"serde\",]\nfile-transport = [ \"serde-impls\", \"serde_json\",]\nsmtp-transport = [ \"bufstream\", \"native-tls\", \"base64\", \"nom\", \"hostname\",]\nsendmail-transport = []\nconnection-pool = [ \"r2d2\",]\n\n[badges.travis-ci]\nrepository = \"lettre/lettre\"\n\n[badges.appveyor]\nrepository = \"lettre/lettre\"\n\n[badges.maintenance]\nstatus = \"actively-developed\"\n\n[badges.is-it-maintained-issue-resolution]\nrepository = \"lettre/lettre\"\n\n[badges.is-it-maintained-open-issues]\nrepository = \"lettre/lettre\"\n\n[dependencies.nom]\nversion = \"^5.0\"\noptional = true\n\n[dependencies.bufstream]\nversion = \"^0.1\"\noptional = true\n\n[dependencies.native-tls]\nversion = \"^0.2\"\noptional = true\n\n[dependencies.base64]\nversion = \"^0.11\"\noptional = true\n\n[dependencies.hostname]\nversion = \"^0.2\"\noptional = true\n\n[dependencies.serde]\nversion = \"^1.0\"\noptional = true\nfeatures = [ \"derive\",]\n\n[dependencies.serde_json]\nversion = \"^1.0\"\noptional = true\n\n[dependencies.r2d2]\nversion = \"^0.8\"\noptional = true\n",
+        "dest": "cargo/vendor/lettre",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
         "contents": "{\"package\": null, \"files\": {}}",
         "dest": "cargo/vendor/lettre",
         "dest-filename": ".cargo-checksum.json"
@@ -2942,6 +2942,12 @@
         "commands": [
             "cp -r --reflink=auto \"flatpak-cargo/git/lettre-2ffdb53/lettre_email\" \"cargo/vendor/lettre_email\""
         ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"lettre_email\"\nversion = \"0.9.2\"\ndescription = \"Email builder\"\nreadme = \"README.md\"\nhomepage = \"http://lettre.at\"\nrepository = \"https://github.com/lettre/lettre\"\nlicense = \"MIT\"\nauthors = [ \"Alexis Mousset <contact@amousset.me>\",]\ncategories = [ \"email\",]\nkeywords = [ \"email\", \"mailer\",]\nedition = \"2018\"\n\n[dev-dependencies]\nglob = \"0.3\"\n\n[dependencies]\nmime = \"^0.3\"\ntime = \"^0.1\"\nbase64 = \"^0.11\"\nlazy_static = \"1.4.0\"\n\n[badges.travis-ci]\nrepository = \"lettre/lettre_email\"\n\n[badges.appveyor]\nrepository = \"lettre/lettre_email\"\n\n[badges.maintenance]\nstatus = \"actively-developed\"\n\n[badges.is-it-maintained-issue-resolution]\nrepository = \"lettre/lettre_email\"\n\n[badges.is-it-maintained-open-issues]\nrepository = \"lettre/lettre_email\"\n\n[dev-dependencies.lettre]\nversion = \"^0.9\"\npath = \"../lettre\"\nfeatures = [ \"smtp-transport\",]\n\n[dependencies.email]\ngit = \"https://github.com/deltachat/rust-email\"\nbranch = \"master\"\n\n[dependencies.uuid]\nversion = \"^1.3\"\nfeatures = [ \"v4\",]\n\n[dependencies.lettre]\nversion = \"^0.9\"\npath = \"../lettre\"\ndefault-features = false\n\n[dependencies.regex]\nversion = \"1.3.1\"\ndefault-features = false\nfeatures = [ \"std\",]\n",
+        "dest": "cargo/vendor/lettre_email",
+        "dest-filename": "Cargo.toml"
     },
     {
         "type": "inline",
@@ -3186,14 +3192,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/mime/mime-0.3.16.crate",
-        "sha256": "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d",
-        "dest": "cargo/vendor/mime-0.3.16"
+        "url": "https://static.crates.io/crates/mime/mime-0.3.17.crate",
+        "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+        "dest": "cargo/vendor/mime-0.3.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d\", \"files\": {}}",
-        "dest": "cargo/vendor/mime-0.3.16",
+        "contents": "{\"package\": \"6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a\", \"files\": {}}",
+        "dest": "cargo/vendor/mime-0.3.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4179,6 +4185,12 @@
     },
     {
         "type": "inline",
+        "contents": "[package]\nname = \"quinn-proto\"\nversion = \"0.9.2\"\nedition = \"2021\"\nrust-version = \"1.59\"\nlicense = \"MIT OR Apache-2.0\"\nrepository = \"https://github.com/quinn-rs/quinn\"\ndescription = \"State machine for the QUIC transport protocol\"\nkeywords = [ \"quic\",]\ncategories = [ \"network-programming\", \"asynchronous\",]\nworkspace = \"..\"\n\n[features]\ndefault = [ \"tls-rustls\", \"log\",]\ntls-rustls = [ \"rustls\", \"webpki\", \"ring\",]\nnative-certs = [ \"rustls-native-certs\",]\nlog = [ \"tracing/log\",]\n\n[dependencies]\nbytes = \"1\"\nrustc-hash = \"1.1\"\nrand = \"0.8\"\nslab = \"0.4\"\nthiserror = \"1.0.21\"\ntracing = \"0.1.10\"\n\n[dev-dependencies]\nassert_matches = \"1.1\"\nhex-literal = \"0.3.0\"\nrcgen = \"0.10.0\"\nlazy_static = \"1\"\n\n[badges.maintenance]\nstatus = \"experimental\"\n\n[dependencies.arbitrary]\nversion = \"1.0.1\"\nfeatures = [ \"derive\",]\noptional = true\n\n[dependencies.ring]\nversion = \"0.16.7\"\noptional = true\n\n[dependencies.rustls]\nversion = \"0.20.4\"\ndefault-features = false\nfeatures = [ \"quic\",]\noptional = true\n\n[dependencies.rustls-native-certs]\nversion = \"0.6\"\noptional = true\n\n[dependencies.tinyvec]\nversion = \"1.1\"\nfeatures = [ \"alloc\",]\n\n[dependencies.webpki]\nversion = \"0.22\"\ndefault-features = false\noptional = true\n\n[dev-dependencies.tracing-subscriber]\nversion = \"0.3.0\"\ndefault-features = false\nfeatures = [ \"env-filter\", \"fmt\", \"ansi\", \"time\", \"local-time\",]\n\n[package.metadata.docs.rs]\nall-features = true\n",
+        "dest": "cargo/vendor/quinn-proto",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
         "contents": "{\"package\": null, \"files\": {}}",
         "dest": "cargo/vendor/quinn-proto",
         "dest-filename": ".cargo-checksum.json"
@@ -4188,6 +4200,12 @@
         "commands": [
             "cp -r --reflink=auto \"flatpak-cargo/git/quinn-11b34a7/quinn-udp\" \"cargo/vendor/quinn-udp\""
         ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"quinn-udp\"\nversion = \"0.3.2\"\nedition = \"2018\"\nrust-version = \"1.59\"\nlicense = \"MIT OR Apache-2.0\"\nrepository = \"https://github.com/quinn-rs/quinn\"\ndescription = \"UDP sockets with ECN information for the QUIC transport protocol\"\nkeywords = [ \"quic\",]\ncategories = [ \"network-programming\", \"asynchronous\",]\nworkspace = \"..\"\n\n[features]\ndefault = [ \"log\",]\nlog = [ \"tracing/log\",]\n\n[dependencies]\nlibc = \"0.2.69\"\nsocket2 = \"0.4\"\ntracing = \"0.1.10\"\n\n[badges.maintenance]\nstatus = \"experimental\"\n\n[dependencies.proto]\npackage = \"quinn-proto\"\npath = \"../quinn-proto\"\nversion = \"0.9\"\ndefault-features = false\n\n[package.metadata.docs.rs]\nall-features = true\n\n[target.\"cfg(windows)\".dependencies.windows-sys]\nversion = \"0.45.0\"\nfeatures = [ \"Win32_Networking_WinSock\",]\n",
+        "dest": "cargo/vendor/quinn-udp",
+        "dest-filename": "Cargo.toml"
     },
     {
         "type": "inline",
@@ -6745,7 +6763,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/async-email/async-imap\"]\ngit = \"https://github.com/async-email/async-imap\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/deltachat/rust-email\"]\ngit = \"https://github.com/deltachat/rust-email\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/async-email/encoded-words\"]\ngit = \"https://github.com/async-email/encoded-words\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/deltachat/lettre\"]\ngit = \"https://github.com/deltachat/lettre\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/quinn-rs/quinn\"]\ngit = \"https://github.com/quinn-rs/quinn\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/deltachat/rust-email\"]\ngit = \"https://github.com/deltachat/rust-email\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/async-email/encoded-words\"]\ngit = \"https://github.com/async-email/encoded-words\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/deltachat/lettre\"]\ngit = \"https://github.com/deltachat/lettre\"\nreplace-with = \"vendored-sources\"\nbranch = \"master\"\n\n[source.\"https://github.com/quinn-rs/quinn\"]\ngit = \"https://github.com/quinn-rs/quinn\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/generated-sources-rust.json
+++ b/generated-sources-rust.json
@@ -130,6 +130,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/alloc-no-stdlib/alloc-no-stdlib-2.0.4.crate",
+        "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
+        "dest": "cargo/vendor/alloc-no-stdlib-2.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3\", \"files\": {}}",
+        "dest": "cargo/vendor/alloc-no-stdlib-2.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/alloc-stdlib/alloc-stdlib-0.2.2.crate",
+        "sha256": "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece",
+        "dest": "cargo/vendor/alloc-stdlib-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece\", \"files\": {}}",
+        "dest": "cargo/vendor/alloc-stdlib-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/android_system_properties/android_system_properties-0.1.5.crate",
         "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
         "dest": "cargo/vendor/android_system_properties-0.1.5"
@@ -169,14 +195,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.69.crate",
-        "sha256": "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800",
-        "dest": "cargo/vendor/anyhow-1.0.69"
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.70.crate",
+        "sha256": "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4",
+        "dest": "cargo/vendor/anyhow-1.0.70"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800\", \"files\": {}}",
-        "dest": "cargo/vendor/anyhow-1.0.69",
+        "contents": "{\"package\": \"7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4\", \"files\": {}}",
+        "dest": "cargo/vendor/anyhow-1.0.70",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -338,27 +364,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.64.crate",
-        "sha256": "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2",
-        "dest": "cargo/vendor/async-trait-0.1.64"
+        "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.68.crate",
+        "sha256": "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842",
+        "dest": "cargo/vendor/async-trait-0.1.68"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2\", \"files\": {}}",
-        "dest": "cargo/vendor/async-trait-0.1.64",
+        "contents": "{\"package\": \"b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842\", \"files\": {}}",
+        "dest": "cargo/vendor/async-trait-0.1.68",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async_zip/async_zip-0.0.11.crate",
-        "sha256": "c50d29ab7e2f9e808cca1a69ea56a36f4ff216f54a41a23aae1fd4afc05cc020",
-        "dest": "cargo/vendor/async_zip-0.0.11"
+        "url": "https://static.crates.io/crates/async_zip/async_zip-0.0.12.crate",
+        "sha256": "b2105142db9c6203b9dadc83b0553394589a6cb31b1449a3b46b42f47c3434d0",
+        "dest": "cargo/vendor/async_zip-0.0.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c50d29ab7e2f9e808cca1a69ea56a36f4ff216f54a41a23aae1fd4afc05cc020\", \"files\": {}}",
-        "dest": "cargo/vendor/async_zip-0.0.11",
+        "contents": "{\"package\": \"b2105142db9c6203b9dadc83b0553394589a6cb31b1449a3b46b42f47c3434d0\", \"files\": {}}",
+        "dest": "cargo/vendor/async_zip-0.0.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -390,14 +416,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/axum/axum-0.6.11.crate",
-        "sha256": "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3",
-        "dest": "cargo/vendor/axum-0.6.11"
+        "url": "https://static.crates.io/crates/axum/axum-0.6.12.crate",
+        "sha256": "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491",
+        "dest": "cargo/vendor/axum-0.6.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3\", \"files\": {}}",
-        "dest": "cargo/vendor/axum-0.6.11",
+        "contents": "{\"package\": \"349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491\", \"files\": {}}",
+        "dest": "cargo/vendor/axum-0.6.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -437,6 +463,19 @@
         "type": "inline",
         "contents": "{\"package\": \"349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce\", \"files\": {}}",
         "dest": "cargo/vendor/base16ct-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base16ct/base16ct-0.2.0.crate",
+        "sha256": "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf",
+        "dest": "cargo/vendor/base16ct-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf\", \"files\": {}}",
+        "dest": "cargo/vendor/base16ct-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -546,6 +585,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.0.2.crate",
+        "sha256": "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1",
+        "dest": "cargo/vendor/bitflags-2.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/blake3/blake3-1.3.3.crate",
         "sha256": "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef",
         "dest": "cargo/vendor/blake3-1.3.3"
@@ -611,14 +663,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/buf_redux/buf_redux-0.8.4.crate",
-        "sha256": "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f",
-        "dest": "cargo/vendor/buf_redux-0.8.4"
+        "url": "https://static.crates.io/crates/brotli/brotli-3.3.4.crate",
+        "sha256": "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68",
+        "dest": "cargo/vendor/brotli-3.3.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f\", \"files\": {}}",
-        "dest": "cargo/vendor/buf_redux-0.8.4",
+        "contents": "{\"package\": \"a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68\", \"files\": {}}",
+        "dest": "cargo/vendor/brotli-3.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/brotli-decompressor/brotli-decompressor-2.3.4.crate",
+        "sha256": "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744",
+        "dest": "cargo/vendor/brotli-decompressor-2.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744\", \"files\": {}}",
+        "dest": "cargo/vendor/brotli-decompressor-2.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bstr/bstr-1.4.0.crate",
+        "sha256": "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09",
+        "dest": "cargo/vendor/bstr-1.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09\", \"files\": {}}",
+        "dest": "cargo/vendor/bstr-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/buffer-redux/buffer-redux-1.0.0.crate",
+        "sha256": "d2886ea01509598caac116942abd33ab5a88fa32acdf7e4abfa0fc489ca520c9",
+        "dest": "cargo/vendor/buffer-redux-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2886ea01509598caac116942abd33ab5a88fa32acdf7e4abfa0fc489ca520c9\", \"files\": {}}",
+        "dest": "cargo/vendor/buffer-redux-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -684,6 +775,19 @@
         "type": "inline",
         "contents": "{\"package\": \"89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be\", \"files\": {}}",
         "dest": "cargo/vendor/bytes-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/camellia/camellia-0.1.0.crate",
+        "sha256": "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30",
+        "dest": "cargo/vendor/camellia-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30\", \"files\": {}}",
+        "dest": "cargo/vendor/camellia-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -806,14 +910,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/chrono/chrono-0.4.23.crate",
-        "sha256": "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f",
-        "dest": "cargo/vendor/chrono-0.4.23"
+        "url": "https://static.crates.io/crates/chrono/chrono-0.4.24.crate",
+        "sha256": "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b",
+        "dest": "cargo/vendor/chrono-0.4.24"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f\", \"files\": {}}",
-        "dest": "cargo/vendor/chrono-0.4.23",
+        "contents": "{\"package\": \"4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b\", \"files\": {}}",
+        "dest": "cargo/vendor/chrono-0.4.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1209,6 +1313,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crypto-bigint/crypto-bigint-0.5.1.crate",
+        "sha256": "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7",
+        "dest": "cargo/vendor/crypto-bigint-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7\", \"files\": {}}",
+        "dest": "cargo/vendor/crypto-bigint-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crypto-common/crypto-common-0.1.6.crate",
         "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3",
         "dest": "cargo/vendor/crypto-common-0.1.6"
@@ -1230,6 +1347,19 @@
         "type": "inline",
         "contents": "{\"package\": \"0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61\", \"files\": {}}",
         "dest": "cargo/vendor/curve25519-dalek-3.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/curve25519-dalek/curve25519-dalek-4.0.0-rc.2.crate",
+        "sha256": "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585",
+        "dest": "cargo/vendor/curve25519-dalek-4.0.0-rc.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585\", \"files\": {}}",
+        "dest": "cargo/vendor/curve25519-dalek-4.0.0-rc.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1404,6 +1534,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/der/der-0.7.1.crate",
+        "sha256": "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0",
+        "dest": "cargo/vendor/der-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0\", \"files\": {}}",
+        "dest": "cargo/vendor/der-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/der-parser/der-parser-8.1.0.crate",
         "sha256": "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1",
         "dest": "cargo/vendor/der-parser-8.1.0"
@@ -1430,40 +1573,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/derive_builder/derive_builder-0.11.2.crate",
-        "sha256": "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3",
-        "dest": "cargo/vendor/derive_builder-0.11.2"
+        "url": "https://static.crates.io/crates/derive_builder/derive_builder-0.12.0.crate",
+        "sha256": "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8",
+        "dest": "cargo/vendor/derive_builder-0.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3\", \"files\": {}}",
-        "dest": "cargo/vendor/derive_builder-0.11.2",
+        "contents": "{\"package\": \"8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_builder-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/derive_builder_core/derive_builder_core-0.11.2.crate",
-        "sha256": "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4",
-        "dest": "cargo/vendor/derive_builder_core-0.11.2"
+        "url": "https://static.crates.io/crates/derive_builder_core/derive_builder_core-0.12.0.crate",
+        "sha256": "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f",
+        "dest": "cargo/vendor/derive_builder_core-0.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4\", \"files\": {}}",
-        "dest": "cargo/vendor/derive_builder_core-0.11.2",
+        "contents": "{\"package\": \"c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_builder_core-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/derive_builder_macro/derive_builder_macro-0.11.2.crate",
-        "sha256": "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68",
-        "dest": "cargo/vendor/derive_builder_macro-0.11.2"
+        "url": "https://static.crates.io/crates/derive_builder_macro/derive_builder_macro-0.12.0.crate",
+        "sha256": "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e",
+        "dest": "cargo/vendor/derive_builder_macro-0.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68\", \"files\": {}}",
-        "dest": "cargo/vendor/derive_builder_macro-0.11.2",
+        "contents": "{\"package\": \"ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_builder_macro-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1521,14 +1664,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/dirs/dirs-4.0.0.crate",
-        "sha256": "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059",
-        "dest": "cargo/vendor/dirs-4.0.0"
+        "url": "https://static.crates.io/crates/dirs/dirs-5.0.0.crate",
+        "sha256": "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd",
+        "dest": "cargo/vendor/dirs-5.0.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059\", \"files\": {}}",
-        "dest": "cargo/vendor/dirs-4.0.0",
+        "contents": "{\"package\": \"dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd\", \"files\": {}}",
+        "dest": "cargo/vendor/dirs-5.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1547,14 +1690,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/dirs-sys/dirs-sys-0.3.7.crate",
-        "sha256": "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6",
-        "dest": "cargo/vendor/dirs-sys-0.3.7"
+        "url": "https://static.crates.io/crates/dirs-sys/dirs-sys-0.4.0.crate",
+        "sha256": "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b",
+        "dest": "cargo/vendor/dirs-sys-0.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6\", \"files\": {}}",
-        "dest": "cargo/vendor/dirs-sys-0.3.7",
+        "contents": "{\"package\": \"04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b\", \"files\": {}}",
+        "dest": "cargo/vendor/dirs-sys-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1625,6 +1768,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ecdsa/ecdsa-0.16.2.crate",
+        "sha256": "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba",
+        "dest": "cargo/vendor/ecdsa-0.16.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba\", \"files\": {}}",
+        "dest": "cargo/vendor/ecdsa-0.16.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ed25519/ed25519-1.5.3.crate",
         "sha256": "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7",
         "dest": "cargo/vendor/ed25519-1.5.3"
@@ -1638,6 +1794,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ed25519/ed25519-2.2.0.crate",
+        "sha256": "be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371",
+        "dest": "cargo/vendor/ed25519-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371\", \"files\": {}}",
+        "dest": "cargo/vendor/ed25519-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ed25519-dalek/ed25519-dalek-1.0.1.crate",
         "sha256": "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d",
         "dest": "cargo/vendor/ed25519-dalek-1.0.1"
@@ -1646,6 +1815,19 @@
         "type": "inline",
         "contents": "{\"package\": \"c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d\", \"files\": {}}",
         "dest": "cargo/vendor/ed25519-dalek-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ed25519-dalek/ed25519-dalek-2.0.0-rc.2.crate",
+        "sha256": "798f704d128510932661a3489b08e3f4c934a01d61c5def59ae7b8e48f19665a",
+        "dest": "cargo/vendor/ed25519-dalek-2.0.0-rc.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"798f704d128510932661a3489b08e3f4c934a01d61c5def59ae7b8e48f19665a\", \"files\": {}}",
+        "dest": "cargo/vendor/ed25519-dalek-2.0.0-rc.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1685,6 +1867,19 @@
         "type": "inline",
         "contents": "{\"package\": \"e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3\", \"files\": {}}",
         "dest": "cargo/vendor/elliptic-curve-0.12.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/elliptic-curve/elliptic-curve-0.13.2.crate",
+        "sha256": "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d",
+        "dest": "cargo/vendor/elliptic-curve-0.13.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d\", \"files\": {}}",
+        "dest": "cargo/vendor/elliptic-curve-0.13.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1908,14 +2103,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/errno/errno-0.2.8.crate",
-        "sha256": "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1",
-        "dest": "cargo/vendor/errno-0.2.8"
+        "url": "https://static.crates.io/crates/errno/errno-0.3.0.crate",
+        "sha256": "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0",
+        "dest": "cargo/vendor/errno-0.3.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1\", \"files\": {}}",
-        "dest": "cargo/vendor/errno-0.2.8",
+        "contents": "{\"package\": \"50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1999,14 +2194,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fast-socks5/fast-socks5-0.8.1.crate",
-        "sha256": "d2687b5a6108f18ba8621e0e618a3be1dcc2768632dad24b7cea1f87975375a9",
-        "dest": "cargo/vendor/fast-socks5-0.8.1"
+        "url": "https://static.crates.io/crates/fast-socks5/fast-socks5-0.8.2.crate",
+        "sha256": "961ce1761191c157145a8c9f0c3ceabecd3a729d65c9a8d443674eaee3420f7e",
+        "dest": "cargo/vendor/fast-socks5-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d2687b5a6108f18ba8621e0e618a3be1dcc2768632dad24b7cea1f87975375a9\", \"files\": {}}",
-        "dest": "cargo/vendor/fast-socks5-0.8.1",
+        "contents": "{\"package\": \"961ce1761191c157145a8c9f0c3ceabecd3a729d65c9a8d443674eaee3420f7e\", \"files\": {}}",
+        "dest": "cargo/vendor/fast-socks5-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2038,14 +2233,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fd-lock/fd-lock-3.0.10.crate",
-        "sha256": "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9",
-        "dest": "cargo/vendor/fd-lock-3.0.10"
+        "url": "https://static.crates.io/crates/fd-lock/fd-lock-3.0.11.crate",
+        "sha256": "9799aefb4a2e4a01cc47610b1dd47c18ab13d991f27bbcaed9296f5a53d5cbad",
+        "dest": "cargo/vendor/fd-lock-3.0.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9\", \"files\": {}}",
-        "dest": "cargo/vendor/fd-lock-3.0.10",
+        "contents": "{\"package\": \"9799aefb4a2e4a01cc47610b1dd47c18ab13d991f27bbcaed9296f5a53d5cbad\", \"files\": {}}",
+        "dest": "cargo/vendor/fd-lock-3.0.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2059,6 +2254,32 @@
         "type": "inline",
         "contents": "{\"package\": \"d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160\", \"files\": {}}",
         "dest": "cargo/vendor/ff-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ff/ff-0.13.0.crate",
+        "sha256": "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449",
+        "dest": "cargo/vendor/ff-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449\", \"files\": {}}",
+        "dest": "cargo/vendor/ff-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fiat-crypto/fiat-crypto-0.1.19.crate",
+        "sha256": "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955",
+        "dest": "cargo/vendor/fiat-crypto-0.1.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955\", \"files\": {}}",
+        "dest": "cargo/vendor/fiat-crypto-0.1.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2155,66 +2376,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures/futures-0.3.26.crate",
-        "sha256": "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84",
-        "dest": "cargo/vendor/futures-0.3.26"
+        "url": "https://static.crates.io/crates/futures/futures-0.3.28.crate",
+        "sha256": "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40",
+        "dest": "cargo/vendor/futures-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-0.3.26",
+        "contents": "{\"package\": \"23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.26.crate",
-        "sha256": "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5",
-        "dest": "cargo/vendor/futures-channel-0.3.26"
+        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.28.crate",
+        "sha256": "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2",
+        "dest": "cargo/vendor/futures-channel-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-channel-0.3.26",
+        "contents": "{\"package\": \"955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-channel-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.26.crate",
-        "sha256": "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608",
-        "dest": "cargo/vendor/futures-core-0.3.26"
+        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.28.crate",
+        "sha256": "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c",
+        "dest": "cargo/vendor/futures-core-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-core-0.3.26",
+        "contents": "{\"package\": \"4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-core-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.26.crate",
-        "sha256": "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e",
-        "dest": "cargo/vendor/futures-executor-0.3.26"
+        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.28.crate",
+        "sha256": "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0",
+        "dest": "cargo/vendor/futures-executor-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-executor-0.3.26",
+        "contents": "{\"package\": \"ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-executor-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.26.crate",
-        "sha256": "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531",
-        "dest": "cargo/vendor/futures-io-0.3.26"
+        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.28.crate",
+        "sha256": "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964",
+        "dest": "cargo/vendor/futures-io-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-io-0.3.26",
+        "contents": "{\"package\": \"4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-io-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2233,53 +2454,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.26.crate",
-        "sha256": "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70",
-        "dest": "cargo/vendor/futures-macro-0.3.26"
+        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.28.crate",
+        "sha256": "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72",
+        "dest": "cargo/vendor/futures-macro-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-macro-0.3.26",
+        "contents": "{\"package\": \"89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-macro-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.26.crate",
-        "sha256": "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364",
-        "dest": "cargo/vendor/futures-sink-0.3.26"
+        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.28.crate",
+        "sha256": "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e",
+        "dest": "cargo/vendor/futures-sink-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-sink-0.3.26",
+        "contents": "{\"package\": \"f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-sink-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.26.crate",
-        "sha256": "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366",
-        "dest": "cargo/vendor/futures-task-0.3.26"
+        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.28.crate",
+        "sha256": "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65",
+        "dest": "cargo/vendor/futures-task-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-task-0.3.26",
+        "contents": "{\"package\": \"76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-task-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.26.crate",
-        "sha256": "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1",
-        "dest": "cargo/vendor/futures-util-0.3.26"
+        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.28.crate",
+        "sha256": "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533",
+        "dest": "cargo/vendor/futures-util-0.3.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-util-0.3.26",
+        "contents": "{\"package\": \"26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-util-0.3.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2324,14 +2545,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gif/gif-0.11.4.crate",
-        "sha256": "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06",
-        "dest": "cargo/vendor/gif-0.11.4"
+        "url": "https://static.crates.io/crates/gif/gif-0.12.0.crate",
+        "sha256": "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045",
+        "dest": "cargo/vendor/gif-0.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06\", \"files\": {}}",
-        "dest": "cargo/vendor/gif-0.11.4",
+        "contents": "{\"package\": \"80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045\", \"files\": {}}",
+        "dest": "cargo/vendor/gif-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2363,14 +2584,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/h2/h2-0.3.16.crate",
-        "sha256": "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d",
-        "dest": "cargo/vendor/h2-0.3.16"
+        "url": "https://static.crates.io/crates/group/group-0.13.0.crate",
+        "sha256": "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63",
+        "dest": "cargo/vendor/group-0.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d\", \"files\": {}}",
-        "dest": "cargo/vendor/h2-0.3.16",
+        "contents": "{\"package\": \"f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63\", \"files\": {}}",
+        "dest": "cargo/vendor/group-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/h2/h2-0.3.18.crate",
+        "sha256": "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21",
+        "dest": "cargo/vendor/h2-0.3.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21\", \"files\": {}}",
+        "dest": "cargo/vendor/h2-0.3.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2475,6 +2709,19 @@
         "type": "inline",
         "contents": "{\"package\": \"7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70\", \"files\": {}}",
         "dest": "cargo/vendor/hex-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hkdf/hkdf-0.12.3.crate",
+        "sha256": "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437",
+        "dest": "cargo/vendor/hkdf-0.12.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437\", \"files\": {}}",
+        "dest": "cargo/vendor/hkdf-0.12.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2662,6 +2909,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/idea/idea-0.5.1.crate",
+        "sha256": "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477",
+        "dest": "cargo/vendor/idea-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477\", \"files\": {}}",
+        "dest": "cargo/vendor/idea-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ident_case/ident_case-1.0.1.crate",
         "sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39",
         "dest": "cargo/vendor/ident_case-1.0.1"
@@ -2701,14 +2961,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/image/image-0.24.5.crate",
-        "sha256": "69b7ea949b537b0fd0af141fff8c77690f2ce96f4f41f042ccb6c69c6c965945",
-        "dest": "cargo/vendor/image-0.24.5"
+        "url": "https://static.crates.io/crates/image/image-0.24.6.crate",
+        "sha256": "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a",
+        "dest": "cargo/vendor/image-0.24.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"69b7ea949b537b0fd0af141fff8c77690f2ce96f4f41f042ccb6c69c6c965945\", \"files\": {}}",
-        "dest": "cargo/vendor/image-0.24.5",
+        "contents": "{\"package\": \"527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a\", \"files\": {}}",
+        "dest": "cargo/vendor/image-0.24.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2818,14 +3078,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/is-terminal/is-terminal-0.4.4.crate",
-        "sha256": "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857",
-        "dest": "cargo/vendor/is-terminal-0.4.4"
+        "url": "https://static.crates.io/crates/is-terminal/is-terminal-0.4.6.crate",
+        "sha256": "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8",
+        "dest": "cargo/vendor/is-terminal-0.4.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857\", \"files\": {}}",
-        "dest": "cargo/vendor/is-terminal-0.4.4",
+        "contents": "{\"package\": \"256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8\", \"files\": {}}",
+        "dest": "cargo/vendor/is-terminal-0.4.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2958,14 +3218,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libc/libc-0.2.139.crate",
-        "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79",
-        "dest": "cargo/vendor/libc-0.2.139"
+        "url": "https://static.crates.io/crates/libc/libc-0.2.140.crate",
+        "sha256": "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c",
+        "dest": "cargo/vendor/libc-0.2.140"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79\", \"files\": {}}",
-        "dest": "cargo/vendor/libc-0.2.139",
+        "contents": "{\"package\": \"99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.140",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libm/libm-0.1.4.crate",
+        "sha256": "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a",
+        "dest": "cargo/vendor/libm-0.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a\", \"files\": {}}",
+        "dest": "cargo/vendor/libm-0.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2984,14 +3257,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libsqlite3-sys/libsqlite3-sys-0.25.2.crate",
-        "sha256": "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa",
-        "dest": "cargo/vendor/libsqlite3-sys-0.25.2"
+        "url": "https://static.crates.io/crates/libsqlite3-sys/libsqlite3-sys-0.26.0.crate",
+        "sha256": "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326",
+        "dest": "cargo/vendor/libsqlite3-sys-0.26.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa\", \"files\": {}}",
-        "dest": "cargo/vendor/libsqlite3-sys-0.25.2",
+        "contents": "{\"package\": \"afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326\", \"files\": {}}",
+        "dest": "cargo/vendor/libsqlite3-sys-0.26.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3023,14 +3296,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.1.4.crate",
-        "sha256": "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4",
-        "dest": "cargo/vendor/linux-raw-sys-0.1.4"
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.3.1.crate",
+        "sha256": "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f",
+        "dest": "cargo/vendor/linux-raw-sys-0.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4\", \"files\": {}}",
-        "dest": "cargo/vendor/linux-raw-sys-0.1.4",
+        "contents": "{\"package\": \"d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3356,19 +3629,6 @@
         "type": "inline",
         "contents": "{\"package\": \"bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a\", \"files\": {}}",
         "dest": "cargo/vendor/nix-0.26.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/nom/nom-4.2.3.crate",
-        "sha256": "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6",
-        "dest": "cargo/vendor/nom-4.2.3"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6\", \"files\": {}}",
-        "dest": "cargo/vendor/nom-4.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3725,6 +3985,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/p256/p256-0.13.0.crate",
+        "sha256": "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47",
+        "dest": "cargo/vendor/p256-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47\", \"files\": {}}",
+        "dest": "cargo/vendor/p256-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/p384/p384-0.11.2.crate",
         "sha256": "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa",
         "dest": "cargo/vendor/p384-0.11.2"
@@ -3733,6 +4006,32 @@
         "type": "inline",
         "contents": "{\"package\": \"dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa\", \"files\": {}}",
         "dest": "cargo/vendor/p384-0.11.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/p384/p384-0.13.0.crate",
+        "sha256": "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209",
+        "dest": "cargo/vendor/p384-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209\", \"files\": {}}",
+        "dest": "cargo/vendor/p384-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/packed_simd_2/packed_simd_2-0.3.8.crate",
+        "sha256": "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282",
+        "dest": "cargo/vendor/packed_simd_2-0.3.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282\", \"files\": {}}",
+        "dest": "cargo/vendor/packed_simd_2-0.3.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3816,6 +4115,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pem-rfc7468/pem-rfc7468-0.7.0.crate",
+        "sha256": "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412",
+        "dest": "cargo/vendor/pem-rfc7468-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412\", \"files\": {}}",
+        "dest": "cargo/vendor/pem-rfc7468-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.2.0.crate",
         "sha256": "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e",
         "dest": "cargo/vendor/percent-encoding-2.2.0"
@@ -3829,14 +4141,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pgp/pgp-0.9.0.crate",
-        "sha256": "991e3f098483f52c454c7cb16720adc010c2966a8845d3c34aad589cb86d3196",
-        "dest": "cargo/vendor/pgp-0.9.0"
+        "url": "https://static.crates.io/crates/pgp/pgp-0.10.1.crate",
+        "sha256": "37a79d6411154d1a9908e7a2c4bac60a5742f6125823c2c30780c7039aef02f0",
+        "dest": "cargo/vendor/pgp-0.10.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"991e3f098483f52c454c7cb16720adc010c2966a8845d3c34aad589cb86d3196\", \"files\": {}}",
-        "dest": "cargo/vendor/pgp-0.9.0",
+        "contents": "{\"package\": \"37a79d6411154d1a9908e7a2c4bac60a5742f6125823c2c30780c7039aef02f0\", \"files\": {}}",
+        "dest": "cargo/vendor/pgp-0.10.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3907,6 +4219,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pkcs1/pkcs1-0.7.1.crate",
+        "sha256": "178ba28ece1961eafdff1991bd1744c29564cbab5d803f3ccb4a4895a6c550a7",
+        "dest": "cargo/vendor/pkcs1-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"178ba28ece1961eafdff1991bd1744c29564cbab5d803f3ccb4a4895a6c550a7\", \"files\": {}}",
+        "dest": "cargo/vendor/pkcs1-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pkcs8/pkcs8-0.9.0.crate",
         "sha256": "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba",
         "dest": "cargo/vendor/pkcs8-0.9.0"
@@ -3920,6 +4245,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pkcs8/pkcs8-0.10.1.crate",
+        "sha256": "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49",
+        "dest": "cargo/vendor/pkcs8-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49\", \"files\": {}}",
+        "dest": "cargo/vendor/pkcs8-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.26.crate",
         "sha256": "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160",
         "dest": "cargo/vendor/pkg-config-0.3.26"
@@ -3928,6 +4266,19 @@
         "type": "inline",
         "contents": "{\"package\": \"6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160\", \"files\": {}}",
         "dest": "cargo/vendor/pkg-config-0.3.26",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/platforms/platforms-3.0.2.crate",
+        "sha256": "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630",
+        "dest": "cargo/vendor/platforms-3.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630\", \"files\": {}}",
+        "dest": "cargo/vendor/platforms-3.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4050,6 +4401,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/primeorder/primeorder-0.13.0.crate",
+        "sha256": "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0",
+        "dest": "cargo/vendor/primeorder-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0\", \"files\": {}}",
+        "dest": "cargo/vendor/primeorder-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-1.0.4.crate",
         "sha256": "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c",
         "dest": "cargo/vendor/proc-macro-error-1.0.4"
@@ -4076,14 +4440,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.51.crate",
-        "sha256": "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6",
-        "dest": "cargo/vendor/proc-macro2-1.0.51"
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.55.crate",
+        "sha256": "1d0dd4be24fcdcfeaa12a432d588dc59bbad6cad3510c67e74a2b6b2fc950564",
+        "dest": "cargo/vendor/proc-macro2-1.0.55"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro2-1.0.51",
+        "contents": "{\"package\": \"1d0dd4be24fcdcfeaa12a432d588dc59bbad6cad3510c67e74a2b6b2fc950564\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.55",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4154,14 +4518,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.27.1.crate",
-        "sha256": "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41",
-        "dest": "cargo/vendor/quick-xml-0.27.1"
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.28.1.crate",
+        "sha256": "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2",
+        "dest": "cargo/vendor/quick-xml-0.28.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41\", \"files\": {}}",
-        "dest": "cargo/vendor/quick-xml-0.27.1",
+        "contents": "{\"package\": \"e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-xml-0.28.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4216,14 +4580,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quote/quote-1.0.23.crate",
-        "sha256": "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b",
-        "dest": "cargo/vendor/quote-1.0.23"
+        "url": "https://static.crates.io/crates/quote/quote-1.0.26.crate",
+        "sha256": "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc",
+        "dest": "cargo/vendor/quote-1.0.26"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b\", \"files\": {}}",
-        "dest": "cargo/vendor/quote-1.0.23",
+        "contents": "{\"package\": \"4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.26",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4411,6 +4775,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.3.5.crate",
+        "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+        "dest": "cargo/vendor/redox_syscall-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.3.crate",
         "sha256": "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b",
         "dest": "cargo/vendor/redox_users-0.4.3"
@@ -4424,14 +4801,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex/regex-1.7.1.crate",
-        "sha256": "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733",
-        "dest": "cargo/vendor/regex-1.7.1"
+        "url": "https://static.crates.io/crates/regex/regex-1.7.3.crate",
+        "sha256": "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d",
+        "dest": "cargo/vendor/regex-1.7.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-1.7.1",
+        "contents": "{\"package\": \"8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-1.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4450,27 +4827,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.6.28.crate",
-        "sha256": "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848",
-        "dest": "cargo/vendor/regex-syntax-0.6.28"
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.6.29.crate",
+        "sha256": "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1",
+        "dest": "cargo/vendor/regex-syntax-0.6.29"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-syntax-0.6.28",
+        "contents": "{\"package\": \"f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-syntax-0.6.29",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/reqwest/reqwest-0.11.14.crate",
-        "sha256": "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9",
-        "dest": "cargo/vendor/reqwest-0.11.14"
+        "url": "https://static.crates.io/crates/reqwest/reqwest-0.11.16.crate",
+        "sha256": "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254",
+        "dest": "cargo/vendor/reqwest-0.11.16"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9\", \"files\": {}}",
-        "dest": "cargo/vendor/reqwest-0.11.14",
+        "contents": "{\"package\": \"27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254\", \"files\": {}}",
+        "dest": "cargo/vendor/reqwest-0.11.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4497,6 +4874,19 @@
         "type": "inline",
         "contents": "{\"package\": \"7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb\", \"files\": {}}",
         "dest": "cargo/vendor/rfc6979-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rfc6979/rfc6979-0.4.0.crate",
+        "sha256": "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2",
+        "dest": "cargo/vendor/rfc6979-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2\", \"files\": {}}",
+        "dest": "cargo/vendor/rfc6979-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4541,14 +4931,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rusqlite/rusqlite-0.28.0.crate",
-        "sha256": "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a",
-        "dest": "cargo/vendor/rusqlite-0.28.0"
+        "url": "https://static.crates.io/crates/rsa/rsa-0.9.0-pre.0.crate",
+        "sha256": "a7bc1d34159d63536b4d89944e9ab5bb952f45db6fa0b8b03c2f8c09fb5b7171",
+        "dest": "cargo/vendor/rsa-0.9.0-pre.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a\", \"files\": {}}",
-        "dest": "cargo/vendor/rusqlite-0.28.0",
+        "contents": "{\"package\": \"a7bc1d34159d63536b4d89944e9ab5bb952f45db6fa0b8b03c2f8c09fb5b7171\", \"files\": {}}",
+        "dest": "cargo/vendor/rsa-0.9.0-pre.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rusqlite/rusqlite-0.29.0.crate",
+        "sha256": "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2",
+        "dest": "cargo/vendor/rusqlite-0.29.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2\", \"files\": {}}",
+        "dest": "cargo/vendor/rusqlite-0.29.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4619,14 +5022,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustix/rustix-0.36.8.crate",
-        "sha256": "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644",
-        "dest": "cargo/vendor/rustix-0.36.8"
+        "url": "https://static.crates.io/crates/rustix/rustix-0.37.6.crate",
+        "sha256": "d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849",
+        "dest": "cargo/vendor/rustix-0.37.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644\", \"files\": {}}",
-        "dest": "cargo/vendor/rustix-0.36.8",
+        "contents": "{\"package\": \"d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-0.37.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4814,6 +5217,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sec1/sec1-0.7.1.crate",
+        "sha256": "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e",
+        "dest": "cargo/vendor/sec1-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e\", \"files\": {}}",
+        "dest": "cargo/vendor/sec1-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/security-framework/security-framework-2.8.2.crate",
         "sha256": "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254",
         "dest": "cargo/vendor/security-framework-2.8.2"
@@ -4853,14 +5269,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde/serde-1.0.152.crate",
-        "sha256": "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb",
-        "dest": "cargo/vendor/serde-1.0.152"
+        "url": "https://static.crates.io/crates/serde/serde-1.0.159.crate",
+        "sha256": "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065",
+        "dest": "cargo/vendor/serde-1.0.159"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb\", \"files\": {}}",
-        "dest": "cargo/vendor/serde-1.0.152",
+        "contents": "{\"package\": \"3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-1.0.159",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4892,27 +5308,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.152.crate",
-        "sha256": "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e",
-        "dest": "cargo/vendor/serde_derive-1.0.152"
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.159.crate",
+        "sha256": "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585",
+        "dest": "cargo/vendor/serde_derive-1.0.159"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_derive-1.0.152",
+        "contents": "{\"package\": \"4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive-1.0.159",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.93.crate",
-        "sha256": "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76",
-        "dest": "cargo/vendor/serde_json-1.0.93"
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.95.crate",
+        "sha256": "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744",
+        "dest": "cargo/vendor/serde_json-1.0.95"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_json-1.0.93",
+        "contents": "{\"package\": \"d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.95",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5061,6 +5477,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signature/signature-2.0.0.crate",
+        "sha256": "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d",
+        "dest": "cargo/vendor/signature-2.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d\", \"files\": {}}",
+        "dest": "cargo/vendor/signature-2.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/slab/slab-0.4.8.crate",
         "sha256": "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d",
         "dest": "cargo/vendor/slab-0.4.8"
@@ -5100,14 +5529,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/socket2/socket2-0.4.7.crate",
-        "sha256": "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd",
-        "dest": "cargo/vendor/socket2-0.4.7"
+        "url": "https://static.crates.io/crates/socket2/socket2-0.4.9.crate",
+        "sha256": "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662",
+        "dest": "cargo/vendor/socket2-0.4.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd\", \"files\": {}}",
-        "dest": "cargo/vendor/socket2-0.4.7",
+        "contents": "{\"package\": \"64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662\", \"files\": {}}",
+        "dest": "cargo/vendor/socket2-0.4.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5147,6 +5576,19 @@
         "type": "inline",
         "contents": "{\"package\": \"67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b\", \"files\": {}}",
         "dest": "cargo/vendor/spki-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spki/spki-0.7.0.crate",
+        "sha256": "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f",
+        "dest": "cargo/vendor/spki-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f\", \"files\": {}}",
+        "dest": "cargo/vendor/spki-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5295,6 +5737,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-2.0.13.crate",
+        "sha256": "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec",
+        "dest": "cargo/vendor/syn-2.0.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/sync_wrapper/sync_wrapper-0.1.2.crate",
         "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160",
         "dest": "cargo/vendor/sync_wrapper-0.1.2"
@@ -5373,14 +5828,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tempfile/tempfile-3.4.0.crate",
-        "sha256": "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95",
-        "dest": "cargo/vendor/tempfile-3.4.0"
+        "url": "https://static.crates.io/crates/tempfile/tempfile-3.5.0.crate",
+        "sha256": "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998",
+        "dest": "cargo/vendor/tempfile-3.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95\", \"files\": {}}",
-        "dest": "cargo/vendor/tempfile-3.4.0",
+        "contents": "{\"package\": \"b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998\", \"files\": {}}",
+        "dest": "cargo/vendor/tempfile-3.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5399,14 +5854,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/testdir/testdir-0.7.2.crate",
-        "sha256": "c31eb500f7513b559ed7e0652894268dbe8ef27b6241b783ce274f4741eae137",
-        "dest": "cargo/vendor/testdir-0.7.2"
+        "url": "https://static.crates.io/crates/testdir/testdir-0.7.3.crate",
+        "sha256": "a45fc921e7c4ad1aedb3484811514f3e5cd187886e0bbf1302c175f7578ef552",
+        "dest": "cargo/vendor/testdir-0.7.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c31eb500f7513b559ed7e0652894268dbe8ef27b6241b783ce274f4741eae137\", \"files\": {}}",
-        "dest": "cargo/vendor/testdir-0.7.2",
+        "contents": "{\"package\": \"a45fc921e7c4ad1aedb3484811514f3e5cd187886e0bbf1302c175f7578ef552\", \"files\": {}}",
+        "dest": "cargo/vendor/testdir-0.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5425,27 +5880,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.38.crate",
-        "sha256": "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0",
-        "dest": "cargo/vendor/thiserror-1.0.38"
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.40.crate",
+        "sha256": "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac",
+        "dest": "cargo/vendor/thiserror-1.0.40"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-1.0.38",
+        "contents": "{\"package\": \"978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-1.0.40",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.38.crate",
-        "sha256": "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f",
-        "dest": "cargo/vendor/thiserror-impl-1.0.38"
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.40.crate",
+        "sha256": "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f",
+        "dest": "cargo/vendor/thiserror-impl-1.0.40"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-impl-1.0.38",
+        "contents": "{\"package\": \"f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-1.0.40",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5555,14 +6010,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tokio/tokio-1.26.0.crate",
-        "sha256": "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64",
-        "dest": "cargo/vendor/tokio-1.26.0"
+        "url": "https://static.crates.io/crates/tokio/tokio-1.27.0.crate",
+        "sha256": "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001",
+        "dest": "cargo/vendor/tokio-1.27.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64\", \"files\": {}}",
-        "dest": "cargo/vendor/tokio-1.26.0",
+        "contents": "{\"package\": \"d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-1.27.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5581,14 +6036,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tokio-macros/tokio-macros-1.8.2.crate",
-        "sha256": "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8",
-        "dest": "cargo/vendor/tokio-macros-1.8.2"
+        "url": "https://static.crates.io/crates/tokio-macros/tokio-macros-2.0.0.crate",
+        "sha256": "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce",
+        "dest": "cargo/vendor/tokio-macros-2.0.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8\", \"files\": {}}",
-        "dest": "cargo/vendor/tokio-macros-1.8.2",
+        "contents": "{\"package\": \"61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-macros-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5672,14 +6127,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml/toml-0.7.2.crate",
-        "sha256": "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6",
-        "dest": "cargo/vendor/toml-0.7.2"
+        "url": "https://static.crates.io/crates/toml/toml-0.7.3.crate",
+        "sha256": "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21",
+        "dest": "cargo/vendor/toml-0.7.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6\", \"files\": {}}",
-        "dest": "cargo/vendor/toml-0.7.2",
+        "contents": "{\"package\": \"b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5698,14 +6153,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.19.4.crate",
-        "sha256": "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825",
-        "dest": "cargo/vendor/toml_edit-0.19.4"
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.19.8.crate",
+        "sha256": "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13",
+        "dest": "cargo/vendor/toml_edit-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.19.4",
+        "contents": "{\"package\": \"239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6127,19 +6582,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/version_check/version_check-0.1.5.crate",
-        "sha256": "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd",
-        "dest": "cargo/vendor/version_check-0.1.5"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd\", \"files\": {}}",
-        "dest": "cargo/vendor/version_check-0.1.5",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/version_check/version_check-0.9.4.crate",
         "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
         "dest": "cargo/vendor/version_check-0.9.4"
@@ -6166,14 +6608,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/walkdir/walkdir-2.3.2.crate",
-        "sha256": "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56",
-        "dest": "cargo/vendor/walkdir-2.3.2"
+        "url": "https://static.crates.io/crates/walkdir/walkdir-2.3.3.crate",
+        "sha256": "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698",
+        "dest": "cargo/vendor/walkdir-2.3.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56\", \"files\": {}}",
-        "dest": "cargo/vendor/walkdir-2.3.2",
+        "contents": "{\"package\": \"36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698\", \"files\": {}}",
+        "dest": "cargo/vendor/walkdir-2.3.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6634,14 +7076,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-0.3.3.crate",
-        "sha256": "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658",
-        "dest": "cargo/vendor/winnow-0.3.3"
+        "url": "https://static.crates.io/crates/winnow/winnow-0.4.1.crate",
+        "sha256": "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28",
+        "dest": "cargo/vendor/winnow-0.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658\", \"files\": {}}",
-        "dest": "cargo/vendor/winnow-0.3.3",
+        "contents": "{\"package\": \"ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6660,14 +7102,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/x25519-dalek/x25519-dalek-1.1.1.crate",
-        "sha256": "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f",
-        "dest": "cargo/vendor/x25519-dalek-1.1.1"
+        "url": "https://static.crates.io/crates/x25519-dalek/x25519-dalek-2.0.0-pre.1.crate",
+        "sha256": "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df",
+        "dest": "cargo/vendor/x25519-dalek-2.0.0-pre.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f\", \"files\": {}}",
-        "dest": "cargo/vendor/x25519-dalek-1.1.1",
+        "contents": "{\"package\": \"e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df\", \"files\": {}}",
+        "dest": "cargo/vendor/x25519-dalek-2.0.0-pre.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {


### PR DESCRIPTION
for me it failed multiple times locally complaining about missing npm dependencies, which ones you ask? that's random, because my instance of `flatpak-node-generator` is still non-deterministic and flaky, so the package that is missing changes with every run, I already had `ms`, `js-tokens` and `wrappy` missing.

I even updated the flathub build tools repo and installed `flatpak-node-generator` again with `pipx`.