### PR TITLE
Use `--disable-gpu` flag

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -208,7 +208,7 @@ modules:
         dest-filename: run.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/delta/deltachat-desktop "$@" --disable-features=WaylandFractionalScaleV1
+          - exec zypak-wrapper /app/delta/deltachat-desktop "$@" --disable-gpu --disable-features=WaylandFractionalScaleV1
 
 
       # dependencies


### PR DESCRIPTION
This solves the issue where DeltaChat Desktop sometimes fail to start up a window.

See https://github.com/deltachat/deltachat-desktop/issues/4676 and https://github.com/flathub/chat.delta.desktop/issues/136