### PR TITLE
simon/reduce indices size

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "revCount": 795599,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.795599%2Brev-3730d8a308f94996a9ba7c7138ede69c1b9ac4ae/0196a676-5403-7dad-a0df-09a2383cfd46/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "all dependencies for generating dependencies for deltachat tauri";
+
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forEachSupportedSystem = f:
+        nixpkgs.lib.genAttrs supportedSystems (system:
+            f {
+                pkgs = import nixpkgs {
+                    inherit system;
+                };
+            });
+  in {
+    devShells = forEachSupportedSystem ({pkgs}: {
+      default = pkgs.mkShell rec {
+        nativeBuildInputs = with pkgs; [
+          
+        ];
+
+        buildInputs = with pkgs; [
+          bash
+          jq
+          nodejs
+          flatpak
+          flatpak-builder
+          pnpm
+          python3
+          appstream
+          librsvg # for flatpak-validate-icon
+        ];
+        env = {};
+      };
+    });
+  };
+}

--- a/generate.sh
+++ b/generate.sh
@@ -126,5 +126,6 @@ node generate_electron_dependency.mjs
 echo "[strip unused versions from pnpm package indices]"
 
 node tool_strip.mjs
+rm generated/used_versions_strip_info.json
 
 echo "[done]"

--- a/generate.sh
+++ b/generate.sh
@@ -123,4 +123,8 @@ echo "[generate manifest that puts electron binary into cache]"
 
 node generate_electron_dependency.mjs
 
+echo "[strip unused versions from pnpm package indices]"
+
+node tool_strip.mjs
+
 echo "[done]"

--- a/record.mjs
+++ b/record.mjs
@@ -23,6 +23,9 @@ function stripSuffix(str, suffix) {
     return str; // Return the original string if it doesn't end with the suffix
 }
 
+/**
+ * TODO: describe what this server does and why
+ */
 const server = createServer((req, res) => {
     if (!req.url) {
         res.writeHead(400)

--- a/record.mjs
+++ b/record.mjs
@@ -60,10 +60,41 @@ const server = createServer((req, res) => {
                             dest,
                             basename(filename)
                         )
+                        let parsed_data = JSON.parse(data);
+
+                        // delete some fields that we don't need
+                        delete parsed_data["keywords"]
+                        delete parsed_data["repository"]
+                        delete parsed_data["contributors"]
+                        delete parsed_data["author"]
+                        delete parsed_data["bugs"]
+                        delete parsed_data["readme"]
+                        delete parsed_data["readmeFilename"]
+                        delete parsed_data["maintainers"]
+                        delete parsed_data["homepage"]
+                        delete parsed_data["description"]
+
+                        for (const key in parsed_data["versions"]) {
+                            if (Object.prototype.hasOwnProperty.call(parsed_data["versions"], key)) {
+                                const element = parsed_data["versions"][key];
+                                delete element["keywords"]
+                                delete element["repository"]
+                                delete element["contributors"]
+                                delete element["maintainers"]
+                                delete element["author"]
+                                delete element["homepage"]
+                                delete element["_npmUser"]
+                                delete element["_npmOperationalInternal"]
+                                delete element["description"]
+                            }
+                        }
+
+                        // data._rev - could be some hash that we need to adjust because we modified the content?
+
                         writeFileSync(
                             the_path,
                             // make it take multiple lines, otherwise git diff would not be more efficient than with inlining into builder manifest
-                            JSON.stringify(JSON.parse(data), null, 1),
+                            JSON.stringify(parsed_data, null, 1),
                             'utf-8')
                         flatpakManifestIndices.push({
                             type: "file",

--- a/record.mjs
+++ b/record.mjs
@@ -11,7 +11,7 @@ const flatpakManifest = {}
 const flatpakManifestIndices = []
 
 /** @type {string[]} */
-const packages_which_should_dl_metdata = []
+const packages_which_should_dl_metadata = []
 
 function stripSuffix(str, suffix) {
     if (str.endsWith(suffix)) {
@@ -123,7 +123,7 @@ const server = createServer((req, res) => {
             }
 
             if (req.url.endsWith(".tgz")) {
-                packages_which_should_dl_metdata.push(
+                packages_which_should_dl_metadata.push(
                     stripSuffix(stripSuffix(req.url, basename(req.url)), '/-/')
                 )
             } else {
@@ -164,7 +164,7 @@ server.listen(PORT, () => {
 
 async function save() {
     // force downloading of index files
-    const indexUrls = packages_which_should_dl_metdata.map(relativeUrl => `http://localhost:${PORT}${relativeUrl}`)
+    const indexUrls = packages_which_should_dl_metadata.map(relativeUrl => `http://localhost:${PORT}${relativeUrl}`)
     // console.log(indexUrls);
 
     await Promise.all(indexUrls.map(url => fetch(url)))

--- a/replay.mjs
+++ b/replay.mjs
@@ -8,6 +8,9 @@ const PORT = 3000;
 
 const base_directory = '../npm-registry-proxy-offline-cache'
 
+/**
+ * TODO: describe what this server does and why
+ */
 const server = createServer(async (req, res) => {
     if (!req.url) {
         res.writeHead(400)

--- a/tool_strip.mjs
+++ b/tool_strip.mjs
@@ -3,6 +3,7 @@ import { readFile, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
 
 /** @type {Record<string,string[]>} */
+// @ts-ignore
 const stripInfo = JSON.parse(await readFile("generated/used_versions_strip_info.json"))
 
 for (const packageName in stripInfo) {
@@ -12,6 +13,7 @@ for (const packageName in stripInfo) {
     if (Object.prototype.hasOwnProperty.call(stripInfo, packageName)) {
         const usedVersions = stripInfo[packageName];
         const pathToIndex = join("generated/proxy-registry-cache-indices", packageName, 'index.json')
+        // @ts-ignore
         const index = JSON.parse(await readFile(pathToIndex))
         const allVersions = Object.keys(index["versions"])
 

--- a/tool_strip.mjs
+++ b/tool_strip.mjs
@@ -1,0 +1,37 @@
+///@ts-check
+import { readFile, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+
+/** @type {Record<string,string[]>} */
+const stripInfo = JSON.parse(await readFile("generated/used_versions_strip_info.json"))
+
+for (const packageName in stripInfo) {
+    if (packageName === "pnpm"){
+        continue
+    }
+    if (Object.prototype.hasOwnProperty.call(stripInfo, packageName)) {
+        const usedVersions = stripInfo[packageName];
+        const pathToIndex = join("generated/proxy-registry-cache-indices", packageName, 'index.json')
+        const index = JSON.parse(await readFile(pathToIndex))
+        const allVersions = Object.keys(index["versions"])
+
+        const unusedVersions = allVersions.filter(version=> !usedVersions.includes(version))
+        // console.log({allVersions, unusedVersions});
+        
+        unusedVersions.forEach(version => {
+            delete index["versions"][version]
+            delete index["time"][version]
+        })
+
+        // Theoretical issue: we may need to adjust "time" object's modified property to the latest available version after filtering
+
+        delete index["users"]
+
+        await writeFile(pathToIndex, JSON.stringify(index, null, 2), 'utf-8')
+    }
+}
+
+// remove pnpm index - since it is propbabaly only needed for version check and we can live without that
+try {
+    await rm(join("generated/proxy-registry-cache-indices", 'pnpm', 'index.json'))
+} catch (error) {}


### PR DESCRIPTION
- **reduce indices size by removing unessesary metadata_keys**
- **fix typo in varname**

my attempt to reduce the size of indices in the repo.

progress:

- [x] remove unessesary metadata (in my local test this already saves 78mb)
- [x] remove unused versions (biggest lasting impact)
