### PR TITLE
fix: delayed notifications on resume from sleep

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -28,7 +28,14 @@ finish-args:
   - --talk-name=com.canonical.AppMenu.Registrar # fix https://github.com/flathub/chat.delta.desktop/issues/118
   - --talk-name=org.kde.StatusNotifierWatcher # fix https://github.com/flathub/chat.delta.desktop/issues/143
   - --talk-name=com.canonical.Unity # D-Bus talk for Unity desktop
-  - --system-talk-name=dummy.permission.to-suppress-chromium-error # see https://github.com/deltachat/deltachat-desktop/issues/5879
+  # Needed for `electron.powerMonitor.on('resume'`,
+  # to re-check for new messages on resume from sleep,
+  # otherwise the re-check may be delayed by at least a few minutes,
+  # or until the window is focused.
+  #
+  # If you want to remove this, see
+  # https://github.com/deltachat/deltachat-desktop/issues/5879.
+  - --system-talk-name=org.freedesktop.login1
   - --env=NOTIFY_IGNORE_PORTAL=1 # fix https://github.com/deltachat/deltachat-desktop/issues/3590
 
 cleanup:


### PR DESCRIPTION
Looks like we do need `org.freedesktop.login1` after all.

Reproduction steps:
1. Unfocus the Delta Chat window.
2. Put the machine to sleep (suspend).
3. Receive a message (you may send it from another account).
4. Wake the machine up from sleep.

See how soon you receive a notification.

You may also check that this MR should work by running

```
flatpak run --system-talk-name=org.freedesktop.login1 chat.delta.desktop
```

Supersedes https://github.com/flathub/chat.delta.desktop/pull/192.
That MR included a bunch of irrelevant changes,
plus the comment was wrong.
Related:
- https://github.com/deltachat/deltachat-desktop/issues/5915